### PR TITLE
Исправить deadlock при холодном старте с download_lists_via_proxy=1

### DIFF
--- a/podkop/files/usr/bin/podkop
+++ b/podkop/files/usr/bin/podkop
@@ -269,7 +269,14 @@ prepare_subscription_cache_for_startup() {
         return 0
     fi
 
-    service_proxy_address="$(get_service_proxy_address 2>/dev/null || echo '')"
+    # Bootstrap subscription directly: sing-box (and its service proxy) is not
+    # running yet at this stage, so download_lists_via_proxy would deadlock here.
+    service_proxy_address=""
+    local _download_lists_via_proxy
+    config_get_bool _download_lists_via_proxy "settings" "download_lists_via_proxy" 0
+    if [ "$_download_lists_via_proxy" -eq 1 ]; then
+        log "download_lists_via_proxy is set, but sing-box is not running yet during startup. Bootstrapping subscription for section '$section' over a direct connection" "info"
+    fi
 
     if wait_for_subscription_connectivity "$section" "$subscription_url" "$service_proxy_address"; then
         if download_subscription_into_cache \


### PR DESCRIPTION
## Проблема

При холодном запуске роутера с включённой галочкой «Скачивать списки через Proxy/VPN» (`download_lists_via_proxy=1`) подкоп не может загрузить подписку и выдаёт ошибку после 12 неудачных попыток. После этого запускается deferred retry worker, который крутится бесконечно — sing-box так и не стартует.

## Причина (chicken-and-egg deadlock)

В `start_main()` (`podkop/files/usr/bin/podkop`) функции вызываются в таком порядке:

1. `prepare_subscription_caches_for_startup` — скачивает подписку
2. `sing_box_configure_service`
3. `/etc/init.d/sing-box start` — запускает sing-box

Подписка нужна для конфигурирования sing-box, поэтому скачивается **до** его запуска.

Когда `download_lists_via_proxy=1`:

- `get_service_proxy_address` возвращает `127.0.0.1:4534` (`SB_SERVICE_MIXED_INBOUND`)
- `wait_for_subscription_connectivity` ходит на этот адрес 12 раз × 5 секунд = 60 секунд
- Все попытки фейлятся, потому что sing-box ещё не запущен и порт 4534 закрыт
- Возвращается ошибка, стартует `start_subscription_startup_retry_worker`
- Worker зовёт `prepare_subscription_caches_for_startup` каждые 10 секунд — и тоже через прокси, который никогда не появится без подписки

Итог — **deadlock**: подписка нужна для старта sing-box, а sing-box нужен для скачивания подписки через прокси.

Дополнительный фактор: `/tmp/sing-box/subscriptions` лежит в tmpfs, поэтому при холодном старте (после ребута) кэша подписки нет и `cache_needs_refresh=1` всегда.

При тёплом перезапуске (reload/restart) проблема может маскироваться: если URL подписки не менялся и кэш на месте, `cache_needs_refresh=0` и прокси не используется вовсе.

## Решение

На этапе bootstrap (в `prepare_subscription_cache_for_startup`) принудительно используем прямое соединение, игнорируя `download_lists_via_proxy`. Это единственный логически возможный путь — sing-box на этом этапе не запущен в любом случае.

После старта sing-box обычные `subscription_update` и `list_update` продолжают использовать прокси согласно настройке.

В лог пишется информационное сообщение, чтобы пользователь видел, что во время startup опция временно игнорируется.

## Что сделано

- Файл `podkop/files/usr/bin/podkop`
- В функции `prepare_subscription_cache_for_startup` вместо `service_proxy_address="$(get_service_proxy_address ...)"` теперь жёстко `service_proxy_address=""`
- Добавлен лог-warning, если `download_lists_via_proxy=1` — чтобы было понятно, что bootstrap пошёл напрямую

## Как протестировать

- [ ] Холодный старт роутера с `download_lists_via_proxy=1` и валидным `subscription_url`
- [ ] Подкоп успешно стартует, подписка скачивается напрямую, sing-box поднимается
- [ ] В syslog появляется сообщение «download_lists_via_proxy is set, but sing-box is not running yet during startup...»
- [ ] После старта `subscription_update` (по крону или вручную) использует прокси как и раньше
- [ ] `list_update` использует прокси как и раньше
- [ ] Холодный старт без `download_lists_via_proxy` (поведение по умолчанию) не изменилось