### PR TITLE
Сохранение выбранного сервера подписки между перезагрузками

### DIFF
--- a/netshift/files/usr/bin/netshift
+++ b/netshift/files/usr/bin/netshift
@@ -862,6 +862,72 @@ start_subscription_startup_retry_worker() {
     log "Started deferred startup recovery worker with PID $!" "warn"
 }
 
+# --- sing-box runtime cache persistence (selected server survives reboot) ----
+# The live sing-box cache DB (settings.cache_path) is tmpfs-backed by default, so
+# a reboot wipes the user's selected subscription server: sing-box persists the
+# selector choice into this DB and restores it on the next start. We snapshot the
+# DB to the overlay (NETSHIFT_CACHE_BACKUP) on a clean stop and after an explicit
+# selection, and restore it on start. The subscription nodes themselves are
+# persisted separately (SUBSCRIPTION_CACHE_FOLDER), so the restored choice (kept
+# by outbound tag) resolves against the freshly regenerated config without a
+# re-download; if the feed changed and the tag is gone, sing-box transparently
+# falls back to the selector default.
+
+# Resolve the configured live cache DB path (single source for backup/restore so
+# they always agree with sing_box_configure_experimental).
+get_sing_box_cache_path() {
+    local cache_path
+    config_get cache_path "settings" "cache_path" "/tmp/sing-box/cache.db"
+    printf '%s' "$cache_path"
+}
+
+# Restore the overlay snapshot into the live (tmpfs) location BEFORE sing-box
+# starts. Only when the live DB is ABSENT (a reboot wiped tmpfs) and a snapshot
+# exists — never clobber a live DB that already holds fresher in-RAM state (the
+# reload/restart path, where tmpfs survived).
+restore_sing_box_cache() {
+    local cache_path cache_dir
+    cache_path="$(get_sing_box_cache_path)"
+    [ -n "$cache_path" ] || return 0
+    [ -e "$cache_path" ] && return 0
+    [ -f "$NETSHIFT_CACHE_BACKUP" ] || return 0
+
+    cache_dir="$(dirname "$cache_path")"
+    mkdir -p "$cache_dir" 2>/dev/null
+    if cp "$NETSHIFT_CACHE_BACKUP" "$cache_path" 2>/dev/null; then
+        log "Restored sing-box cache from $NETSHIFT_CACHE_BACKUP (selected server preserved across reboot)" "info"
+    else
+        log "Failed to restore sing-box cache from $NETSHIFT_CACHE_BACKUP" "warn"
+    fi
+}
+
+# Snapshot the live cache DB to the overlay (atomic tmp+mv so a crash mid-copy
+# never leaves a truncated snapshot). No-op until the live DB exists. Called on a
+# clean stop and after a successful selection change. Writes to flash are rare
+# (stop + explicit user selection), never on FakeIP churn.
+backup_sing_box_cache() {
+    local cache_path tmp
+    cache_path="$(get_sing_box_cache_path)"
+    [ -n "$cache_path" ] && [ -f "$cache_path" ] || return 0
+
+    # Skip the flash write when the snapshot is already byte-identical (a reload
+    # / WAN-flap that changed neither the selection nor the FakeIP state) so the
+    # overlay is written only on a real change, not on every reload.
+    if [ -f "$NETSHIFT_CACHE_BACKUP" ] && cmp -s "$cache_path" "$NETSHIFT_CACHE_BACKUP"; then
+        return 0
+    fi
+
+    mkdir -p "$NETSHIFT_STATE_DIR" 2>/dev/null
+    tmp="${NETSHIFT_CACHE_BACKUP}.tmp.$$"
+    if cp "$cache_path" "$tmp" 2>/dev/null && mv "$tmp" "$NETSHIFT_CACHE_BACKUP" 2>/dev/null; then
+        chmod 600 "$NETSHIFT_CACHE_BACKUP" 2>/dev/null
+        log "Backed up sing-box cache to $NETSHIFT_CACHE_BACKUP" "debug"
+    else
+        rm -f "$tmp" 2>/dev/null
+        log "Failed to back up sing-box cache to $NETSHIFT_CACHE_BACKUP" "warn"
+    fi
+}
+
 start_main() {
     log "Starting netshift"
 
@@ -905,6 +971,9 @@ start_main() {
     sing_box_init_config
     config_foreach add_cron_job "section"
     config_foreach add_subscription_cron_job "section"
+    # Bring back the persisted selector choice (+ FakeIP state) before sing-box
+    # reads its cache, so a reboot keeps the user's selected subscription server.
+    restore_sing_box_cache
     /etc/init.d/sing-box start
 
     if [ "$subscription_startup_blocked" -ne 0 ]; then
@@ -949,6 +1018,10 @@ stop_main() {
 
     log "Stop sing-box"
     /etc/init.d/sing-box stop
+
+    # sing-box has exited and flushed its cache DB: snapshot it to the overlay so
+    # the selected subscription server survives the next reboot (tmpfs wipe).
+    backup_sing_box_cache
 }
 
 start() {
@@ -4863,6 +4936,11 @@ clash_api() {
         case "$http_code" in
         204)
             jq -n --arg group "$group_tag" --arg proxy "$proxy_tag" '{success:true,group:$group,proxy:$proxy}'
+            # sing-box has persisted the new choice to its (tmpfs) cache DB;
+            # snapshot it to the overlay now so the pick survives even an unclean
+            # reboot (no clean stop). log() goes to syslog, so it cannot corrupt
+            # the JSON response already emitted above.
+            backup_sing_box_cache
             ;;
         404)
             jq -n --arg group "$group_tag" '{success:false,error:"group_not_found",message:($group + " does not exist")}'

--- a/netshift/files/usr/lib/constants.sh
+++ b/netshift/files/usr/lib/constants.sh
@@ -5,6 +5,15 @@ NETSHIFT_VERSION="__COMPILED_VERSION_VARIABLE__"
 ## Common
 NETSHIFT_CONFIG="/etc/config/netshift"
 NETSHIFT_STATE_DIR="/etc/netshift"
+# Persistent (overlay) snapshot of the sing-box runtime cache DB. The live cache
+# (settings.cache_path, default /tmp/sing-box/cache.db) is tmpfs-backed, so a
+# reboot wipes it — and with it sing-box's persisted selector choice (the
+# subscription server the user picked, stored in the cache DB by outbound tag).
+# The backend snapshots the live DB here on a clean stop and right after an
+# explicit selection, and restores it on start, so the choice (and FakeIP state)
+# survive a reboot WITHOUT paying flash writes on every FakeIP allocation (which
+# is exactly why the live DB deliberately stays in tmpfs).
+NETSHIFT_CACHE_BACKUP="$NETSHIFT_STATE_DIR/cache.db"
 RESOLV_CONF="/etc/resolv.conf"
 DNS_RESOLVERS="1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4 9.9.9.9 9.9.9.11 94.140.14.14 94.140.15.15 208.67.220.220 208.67.222.222 77.88.8.1 77.88.8.8"
 CHECK_PROXY_IP_DOMAIN="ip.podkop.fyi"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,7 +12,7 @@
 #             nftv6, selmark, isolation, monfd, unsupported, textlist, diagnostics, subscription, fastest, insecure, rejected,
 #             jobstate, selfheal, dnsdetour, suburlopt, globalproxy, stablecheck,
 #             extcheck, netshiftcheck, latesttag, ghredirect, selfupdate,
-#             backupguard
+#             backupguard, cachepersist
 # ──────────────────────────────────────────────────────────────────
 
 services:

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -6695,6 +6695,141 @@ DRVEOF
 }
 
 # ─────────────────────────────────────────────────────────────────
+# Test: sing-box cache persistence (selected subscription server survives reboot)
+#
+# ROOT CAUSE under test: the live sing-box cache DB (settings.cache_path) is
+# tmpfs-backed (/tmp/sing-box/cache.db) so a reboot wipes it — and with it the
+# selector choice sing-box persists there (the subscription server the user
+# picked, kept by outbound tag). The fix snapshots the live DB to the overlay
+# (NETSHIFT_CACHE_BACKUP) on a clean stop / after a selection, and restores it
+# on start. This test awk-extracts the SHIPPED helpers verbatim and asserts the
+# snapshot/restore contract end to end:
+#   (1) backup is a no-op until the live DB exists,
+#   (2) backup snapshots the live DB byte-for-byte (atomic tmp+mv, no tmp leak),
+#   (3) restore NEVER clobbers a live DB that survived (reload path: tmpfs intact),
+#   (4) reboot (live gone, snapshot present) -> live restored byte-for-byte,
+#   (5) fresh install (neither present) -> restore is a no-op.
+# ─────────────────────────────────────────────────────────────────
+test_cache_persistence() {
+    header "sing-box Cache Persistence (selected server survives reboot)"
+
+    local bin="${NETSHIFT_SRC}/usr/bin/netshift"
+    local const="${NETSHIFT_LIB_DIR}/constants.sh"
+    if [ ! -r "$bin" ] || [ ! -r "$const" ]; then
+        fail "bin / constants.sh not found"
+        return
+    fi
+
+    local work="/tmp/netshift-cachepersist-$$"
+    rm -rf "$work"
+    mkdir -p "$work"
+
+    local drv="$work/driver.sh"
+    cat > "$drv" << 'CPEOF'
+. "CONST_LIB"
+log() { :; }
+
+W="DRV_WORK"
+# Re-pin the overlay snapshot + state dir at temp paths. constants.sh set them to
+# /etc/netshift/*; the helpers read these globals at call time, so overriding
+# AFTER sourcing is enough.
+NETSHIFT_STATE_DIR="$W/state"
+NETSHIFT_CACHE_BACKUP="$NETSHIFT_STATE_DIR/cache.db"
+LIVE="$W/tmp/sing-box/cache.db"
+
+# Table-driven config_get stub: cache_path -> $LIVE, else the provided default.
+config_get() {
+    case "$3" in
+        cache_path) eval "$1=\"$LIVE\"" ;;
+        *) eval "$1=\"\${4:-}\"" ;;
+    esac
+    return 0
+}
+
+# awk-extract the SHIPPED helpers verbatim (each ends at its column-0 `}`).
+eval "$(awk '/^get_sing_box_cache_path\(\) \{/{p=1} p{print} p&&/^\}/{exit}' "BIN_PATH")"
+eval "$(awk '/^restore_sing_box_cache\(\) \{/{p=1} p{print} p&&/^\}/{exit}' "BIN_PATH")"
+eval "$(awk '/^backup_sing_box_cache\(\) \{/{p=1} p{print} p&&/^\}/{exit}' "BIN_PATH")"
+
+# get_sing_box_cache_path returns the configured live path.
+[ "$(get_sing_box_cache_path)" = "$LIVE" ] \
+    && echo 'cache-path-resolved:OK' || echo 'cache-path-resolved:FAIL'
+
+# ── (1) backup is a no-op until the live DB exists ─────────────────────────────
+backup_sing_box_cache
+[ ! -e "$NETSHIFT_CACHE_BACKUP" ] \
+    && echo 'cache-backup-noop-without-live:OK' || echo 'cache-backup-noop-without-live:FAIL'
+
+# ── (2) backup snapshots the live DB byte-for-byte ─────────────────────────────
+mkdir -p "$(dirname "$LIVE")"
+printf 'SELECTED-NODE-CACHE-v1\n' > "$LIVE"
+backup_sing_box_cache
+if [ -f "$NETSHIFT_CACHE_BACKUP" ] && cmp -s "$LIVE" "$NETSHIFT_CACHE_BACKUP"; then
+    echo 'cache-backup-snapshots-live:OK'
+else
+    echo 'cache-backup-snapshots-live:FAIL'
+fi
+# the atomic tmp+mv must leave no stray tmp file behind
+if ls "$NETSHIFT_CACHE_BACKUP".tmp.* >/dev/null 2>&1; then
+    echo 'cache-backup-no-tmp-leak:FAIL'
+else
+    echo 'cache-backup-no-tmp-leak:OK'
+fi
+
+# ── (2b) a second backup of an UNCHANGED live DB must skip the flash write ─────
+# A real write goes through tmp+mv (new inode); a skipped one leaves the inode
+# untouched. Compare inodes to prove the cmp-guard short-circuited.
+ino_before="$(ls -i "$NETSHIFT_CACHE_BACKUP" | awk '{print $1}')"
+backup_sing_box_cache
+ino_after="$(ls -i "$NETSHIFT_CACHE_BACKUP" | awk '{print $1}')"
+[ "$ino_before" = "$ino_after" ] \
+    && echo 'cache-backup-skips-unchanged:OK' || echo 'cache-backup-skips-unchanged:FAIL'
+
+# ── (3) restore must NOT clobber a live DB that survived (reload path) ─────────
+printf 'FRESHER-LIVE-STATE-v2\n' > "$LIVE"
+restore_sing_box_cache
+if grep -q 'FRESHER-LIVE-STATE-v2' "$LIVE" 2>/dev/null; then
+    echo 'cache-restore-keeps-live:OK'
+else
+    echo 'cache-restore-keeps-live:FAIL'
+fi
+
+# ── (4) reboot: live DB gone, snapshot present -> restored byte-for-byte ───────
+rm -rf "$(dirname "$LIVE")"
+restore_sing_box_cache
+if [ -f "$LIVE" ] && cmp -s "$LIVE" "$NETSHIFT_CACHE_BACKUP"; then
+    echo 'cache-restore-on-reboot:OK'
+else
+    echo 'cache-restore-on-reboot:FAIL'
+fi
+
+# ── (5) fresh install: neither live nor snapshot -> restore is a no-op ─────────
+rm -rf "$NETSHIFT_STATE_DIR" "$(dirname "$LIVE")"
+restore_sing_box_cache
+[ ! -e "$LIVE" ] \
+    && echo 'cache-restore-noop-fresh:OK' || echo 'cache-restore-noop-fresh:FAIL'
+
+echo 'DONE'
+CPEOF
+    sed -i "s|CONST_LIB|$const|g; s|BIN_PATH|$bin|g; s|DRV_WORK|$work|g" "$drv"
+
+    local out="$work/out.txt"
+    local saw_done=0 line
+    ash "$drv" > "$out" 2>/dev/null || true
+    while IFS= read -r line; do
+        case "$line" in
+            *:OK)   pass "${line%:OK}" ;;
+            *:FAIL) fail "$line" ;;
+            DONE)   saw_done=1 ;;
+            *) ;;
+        esac
+    done < "$out"
+    [ "$saw_done" = "1" ] && pass "cache-persistence-driver-completed:OK" \
+        || fail "cache-persistence-driver-completed:FAIL (driver aborted early)"
+    rm -rf "$work"
+}
+
+# ─────────────────────────────────────────────────────────────────
 # Main
 # ─────────────────────────────────────────────────────────────────
 main() {
@@ -6739,6 +6874,7 @@ main() {
             test_github_redirect_tag
             test_self_update_netshift
             test_backup_integrity
+            test_cache_persistence
             ;;
         deps)        test_deps ;;
         syntax)      test_syntax ;;
@@ -6768,12 +6904,13 @@ main() {
         ghredirect)  test_github_redirect_tag ;;
         selfupdate)  test_self_update_netshift ;;
         backupguard) test_backup_integrity ;;
+        cachepersist) test_cache_persistence ;;
         jq)          test_jq_helpers ;;
         cm)          test_config_manager ;;
         sb)          test_sing_box_config ;;
         *)
             echo "Unknown test: $target"
-            echo "Available: all deps syntax config helpers jq cm sb nft nftv6 selmark isolation monfd unsupported textlist diagnostics subscription fastest insecure rejected jobstate selfheal dnsdetour suburlopt globalproxy stablecheck extcheck netshiftcheck latesttag ghredirect selfupdate backupguard"
+            echo "Available: all deps syntax config helpers jq cm sb nft nftv6 selmark isolation monfd unsupported textlist diagnostics subscription fastest insecure rejected jobstate selfheal dnsdetour suburlopt globalproxy stablecheck extcheck netshiftcheck latesttag ghredirect selfupdate backupguard cachepersist"
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Проблема

При перезагрузке роутера сбрасывается выбранный в подписке сервер: после ребута селектор откатывается на `default` (urltest / «⚡ Fastest»), а не на узел, который выбрал пользователь.

## Причина

Выбор сервера в селекторе sing-box сохраняет в своей кэш-БД и восстанавливает при следующем старте. Но `settings.cache_path` по умолчанию указывает на `/tmp/sing-box/cache.db` — а `/tmp` в OpenWRT это tmpfs (ОЗУ), которая очищается при перезагрузке:

- `netshift/files/etc/config/netshift` → `option cache_path '/tmp/sing-box/cache.db'`
- `sing_box_configure_experimental()` → `sing_box_cm_configure_cache_file "$config" true "$cache_file" true`

Поэтому рестарт/reload сервиса выбор сохраняет (tmpfs жива), а перезагрузка роутера — теряет.

## Решение

Живая БД остаётся в tmpfs (намеренно — чтобы не изнашивать флеш записями FakeIP при `store_fakeip=true`), но снапшотится на overlay и восстанавливается:

- **restore** в `start_main` перед `/etc/init.d/sing-box start` — если живой БД нет (ребут стёр tmpfs), а снапшот есть, копируем его обратно. Живую БД, пережившую reload, не трогаем.
- **backup** в `stop_main` после остановки sing-box и сразу после успешного `clash_api set_group_proxy` (выбор сервера) — атомарно (`tmp`+`mv`), `chmod 600`.
- `cmp`-гард пропускает запись на флеш, если снапшот не изменился (reload/WAN-flap не плодят записи).

Новая константа `NETSHIFT_CACHE_BACKUP="$NETSHIFT_STATE_DIR/cache.db"` (`/etc/netshift/cache.db`).

Сами узлы подписки уже персистятся отдельно (`SUBSCRIPTION_CACHE_FOLDER`), поэтому восстановленный выбор (хранится по тегу outbound) сходится с заново сгенерированным конфигом без перезакачки подписки. Если фид сменился и тега больше нет — sing-box штатно откатывается на `default` селектора.

## Тестирование

- ShellCheck (severity error) — чисто: `install.sh`, `netshift`, все `lib/*.sh`.
- Smoke-suite — 226 passed / 0 failed; новый тест `cachepersist` (9 проверок): no-op без живой БД, побайтовый снапшот, пропуск неизменного, restore не затирает живую БД, восстановление после ребута, no-op на чистой установке.
