### PR TITLE
feat(transport): support httpupgrade in the subscription parser

### DIFF
--- a/String-example.md
+++ b/String-example.md
@@ -31,6 +31,10 @@ vless://fe0f0941-09a9-4e46-bc69-e00190d7bb9c@127.0.0.1:10156?type=ws&encryption=
 vless://599e8659-e2ef-47d9-bf72-2f9b4b673474@127.0.0.1:36567?type=ws&encryption=none&path=%2Fwspath&host=google.com&security=tls&fp=chrome&alpn=h2%2Chttp%2F1.1&allowInsecure=1&sni=google.com#vless-websocket-tls-insecure
 vless://4d21ce62-8723-4c4d-93e3-d586b107aa40@127.0.0.1:51394?type=ws&encryption=none&path=%2Fwspath&host=google.com&security=tls&fp=chrome&alpn=h2%2Chttp%2F1.1&sni=google.com&ech=AF3%2BDQBZAAAgACD7fjrtDMlcigKXFBKoLn6UDB9%2BWR6HBZpY96DlBiD%2BIwAkAAEAAQABAAIAAQADAAIAAQACAAIAAgADAAMAAQADAAIAAwADAApnb29nbGUuY29tAAA%3D#vless-websocket-tls-ech
 
+# HTTPUpgrade
+vless://9d3f1c0a-2b4e-4f6a-8c1d-7e9a0b2c3d4e@127.0.0.1:23145?type=httpupgrade&encryption=none&path=%2Fhupath&host=google.com&security=tls&sni=google.com#vless-httpupgrade-tls
+trojan://trojanpass@127.0.0.1:23146?type=httpupgrade&security=tls&sni=google.com&path=%2Fhupath#trojan-httpupgrade-tls
+
 # gRPC
 vless://974b39e3-f7bf-42b9-933c-16699c635e77@127.0.0.1:15633?type=grpc&encryption=none&serviceName=TunService&authority=&security=none#vless-gRPC-none
 vless://651e7eca-5152-46f1-baf2-d502e0af7b27@127.0.0.1:28535?type=grpc&encryption=none&serviceName=TunService&authority=authority&security=reality&pbk=nhZ7NiKfcqESa5ZeBFfsq9o18W-OWOAHLln9UmuVXSk&fp=chrome&sni=google.com&sid=11cbaeaa&spx=%2F#vless-gRPC-reality

--- a/netshift/files/usr/lib/sing_box_config_facade.sh
+++ b/netshift/files/usr/lib/sing_box_config_facade.sh
@@ -363,6 +363,18 @@ _add_outbound_transport() {
         xhttp_mode=$(url_get_query_param "$url" "mode")
         config=$(sing_box_cm_set_xhttp_transport_for_outbound "$config" "$outbound_tag" "$xhttp_path" "$xhttp_host" "$xhttp_mode")
         ;;
+    httpupgrade)
+        # sing-box's httpupgrade transport (upstream since 1.8, no extended core
+        # required). The Host header lives in a top-level "host" field; when the
+        # link omits it we fall back to the sni so the Host matches the TLS SNI,
+        # which is how most TLS-fronted httpupgrade deployments are set up.
+        local httpupgrade_path httpupgrade_host httpupgrade_sni
+        httpupgrade_path=$(url_get_query_param "$url" "path")
+        httpupgrade_host=$(url_get_query_param "$url" "host")
+        httpupgrade_sni=$(url_get_query_param "$url" "sni")
+        [ -n "$httpupgrade_host" ] || httpupgrade_host="$httpupgrade_sni"
+        config=$(sing_box_cm_set_httpupgrade_transport_for_outbound "$config" "$outbound_tag" "$httpupgrade_path" "$httpupgrade_host")
+        ;;
     *)
         log "Unknown transport '$transport' detected." "error"
         ;;

--- a/netshift/files/usr/lib/sing_box_config_manager.sh
+++ b/netshift/files/usr/lib/sing_box_config_manager.sh
@@ -890,6 +890,42 @@ sing_box_cm_set_ws_transport_for_outbound() {
 }
 
 #######################################
+# Set HTTPUpgrade transport settings for an outbound in a sing-box JSON
+# configuration. sing-box's httpupgrade transport carries the Host header in a
+# top-level "host" field (unlike ws, which nests it under headers.Host). When
+# host is empty sing-box falls back to the server address, which matches the
+# common TLS-SNI==server deployment, so host is emitted only when provided.
+#######################################
+sing_box_cm_set_httpupgrade_transport_for_outbound() {
+    local config="$1"
+    local tag="$2"
+    local path="$3"
+    local host="$4"
+
+    [ -n "$path" ] || path="/"
+
+    echo "$config" | jq \
+        --arg tag "$tag" \
+        --arg path "$path" \
+        --arg host "$host" \
+        '.outbounds |= map(
+            if .tag == $tag then
+                . + {
+                    transport: (
+                        {
+                            type: "httpupgrade",
+                            path: $path
+                        }
+                        + (if $host != "" then {host: $host} else {} end)
+                    )
+                }
+            else
+                .
+            end
+        )'
+}
+
+#######################################
 # Set HTTP/2 transport settings for an outbound in a sing-box JSON configuration.
 # Used for VMess net=h2 links (sing-box "http" transport). HTTP/2 transport
 # mandates TLS, so the caller must also set TLS on the outbound.

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1255,6 +1255,43 @@ case "$xray_uri" in
 esac
 rm -f "$xray_src"
 
+# ── (3c) httpupgrade transport via a vless URL ?type=httpupgrade ─────────────
+#         httpupgrade is an upstream sing-box transport (shipped since 1.8, no
+#         extended core required), so the transport MUST be applied regardless
+#         of the sing-box-extended gate. The Host header falls back to the sni
+#         when ?host= is absent, matching the common TLS-fronted deployment
+#         where the Host equals the TLS SNI.
+out_hu=$(sing_box_cf_add_proxy_outbound "$base" "hup" "vless://99999999-aaaa-bbbb-cccc-dddddddddddd@h.example.com:443?type=httpupgrade&security=tls&sni=h.example.com&path=/hu" "0")
+printf '%s' "$out_hu" | jq -e '.outbounds[0].transport.type=="httpupgrade"' >/dev/null 2>&1 \
+    && echo 'us-httpupgrade-url-type:OK' || echo 'us-httpupgrade-url-type:FAIL'
+printf '%s' "$out_hu" | jq -e '.outbounds[0].transport.path=="/hu"' >/dev/null 2>&1 \
+    && echo 'us-httpupgrade-url-path:OK' || echo 'us-httpupgrade-url-path:FAIL'
+# host omitted in the link → falls back to the sni.
+printf '%s' "$out_hu" | jq -e '.outbounds[0].transport.host=="h.example.com"' >/dev/null 2>&1 \
+    && echo 'us-httpupgrade-url-host-from-sni:OK' || echo 'us-httpupgrade-url-host-from-sni:FAIL'
+# No extended gate: with extended OFF the transport is STILL applied (contrast
+# with xhttp/splithttp above, which require the extended core).
+is_sing_box_extended() { return 1; }
+out_hu_off=$(sing_box_cf_add_proxy_outbound "$base" "hupo" "vless://99999999-aaaa-bbbb-cccc-dddddddddddd@h.example.com:443?type=httpupgrade&security=tls&sni=h.example.com&path=/hu" "0")
+printf '%s' "$out_hu_off" | jq -e '.outbounds[0].transport.type=="httpupgrade"' >/dev/null 2>&1 \
+    && echo 'us-httpupgrade-no-extended-gate:OK' || echo 'us-httpupgrade-no-extended-gate:FAIL'
+is_sing_box_extended() { return 0; }
+# Whole-chain: the httpupgrade outbound passes a real sing-box check (stock core
+# accepts httpupgrade, so this asserts OK rather than SKIP).
+hu_full="/tmp/us-hu-full-$$.json"
+printf '%s' "$out_hu" | jq '{
+    log: { level: "error" },
+    inbounds: [],
+    outbounds: (.outbounds + [ { type: "direct", tag: "direct-out" } ]),
+    route: { final: "direct-out" }
+}' > "$hu_full" 2>/dev/null
+if sing-box -c "$hu_full" check > /dev/null 2>&1; then
+    echo 'us-httpupgrade-singbox-check:OK'
+else
+    echo 'us-httpupgrade-singbox-check:FAIL'
+fi
+rm -f "$hu_full"
+
 rm -f "$WARN_LOG"
 echo 'DONE'
 USEOF


### PR DESCRIPTION
Description: 

Closes #27

### Что

Добавлена поддержка транспорта `httpupgrade` в парсер подписок/ссылок.

### Зачем

Фронтенд-валидатор уже принимает `type=httpupgrade`, но в бэкенде обработчика не было:
`_add_outbound_transport` проваливался в ветку `*)` «Unknown transport 'httpupgrade' detected»
и терял транспорт. В итоге vless/trojan-аутбаунд получал TLS, но без блока `transport`, и
sing-box шёл обычным TLS на httpupgrade-сервер - рукопожатие не проходило, и узел показывал
N/A в URLTest.

httpupgrade - апстрим-транспорт sing-box (есть с 1.8), поэтому, в отличие от xhttp, ему не
нужны extended-ядро и гейт.

### Изменения
- `sing_box_config_manager.sh`: новая функция `sing_box_cm_set_httpupgrade_transport_for_outbound`,
  формирующая `transport:{type:"httpupgrade", path, host}`. У httpupgrade заголовок Host -это
  поле `host` верхнего уровня (а не вложенное в `headers`, как у ws); `host` пишется только когда
  он задан (иначе sing-box берёт адрес сервера).
- `sing_box_config_facade.sh`: новая ветка `httpupgrade)` в `_add_outbound_transport`, читает
  `path`/`host`, с фоллбэком `host` на `sni` (соответствует TLS-фронтед-схемам, где Host == SNI).
  Без extended-гейта.
- `tests/entrypoint.sh`: новые смоук-проверки (3c) - транспорт применяется при extended-гейте
  как ON, так и OFF; `host` корректно берётся из sni; собранный конфиг проходит реальный
  `sing-box check`.
- `String-example.md`: фикстуры httpupgrade для vless и trojan.

### Тестирование
Проверено на живом роутере (sing-box 1.13.14-extended): узлы Trojan и VLESS с `type=httpupgrade`
после изменения переходят из N/A в рабочее состояние (~150 мс по замеру задержки через clash-api),
а `sing-box check` принимает сгенерированный конфиг. Новые смоук-тесты проходят на реальном sing-box.